### PR TITLE
Set Modal.openCount floor to 0

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -277,7 +277,7 @@ class Modal extends React.Component {
       const modalOpenClassNameRegex = new RegExp(`(^| )${modalOpenClassName}( |$)`);
       document.body.className = document.body.className.replace(modalOpenClassNameRegex, ' ').trim();
     }
-    Modal.openCount -= 1;
+    Modal.openCount = Math.max(0, Modal.openCount - 1);
 
     setScrollbarWidth(this._originalBodyPadding);
   }


### PR DESCRIPTION
Fixes bug described in https://github.com/reactstrap/reactstrap/issues/1279 where Modal.openCount becomes negative after multiple .destroy() calls, preventing "modal-open" from being added to document.body.

Solution is prevent Modal.openCount from going below a minimum of 0, rejecting decrements that result in an erroneous negative value.

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->


<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
